### PR TITLE
feat: Basic user role + cta banner

### DIFF
--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
   const userFirstName = user?.name.split(' ')[0];
 
   return (
-    <div className="flex flex-col justify-center w-full h-full">
+    <div className="flex flex-col justify-center w-full">
       {!user?.onboardingComplete && <OnboardingModal />}
 
       <div className="flex flex-col gap-2">

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,22 +1,28 @@
+import { AlertBanner } from '@/components/AlertBanner';
 import { AppSidebar } from '@/components/AppSidebar';
 import ProtectedLayout from '@/components/layouts/ProtectedLayout';
 import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
+import { getUserRole } from '@/lib/queries/userRole';
 import { PanelLeftIcon } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
 
-export default function Layout({
+export default async function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const userRole = await getUserRole();
+
+  let showBanner = userRole === 'Basic';
+
   return (
     <SidebarProvider>
       <ProtectedLayout>
         <AppSidebar />
-        <main className="w-full mx-8 mb-8 mt-4 md:m-8">
+        <main className="w-full space-y-8 mx-8 mb-8 mt-4 md:m-8">
           <div className="md:hidden w-full flex flex-row justify-between items-center mb-8">
             <SidebarTrigger />
             <Link href="/" prefetch={true}>
@@ -29,6 +35,21 @@ export default function Layout({
             </Link>
             <PanelLeftIcon className="invisible" />
           </div>
+
+          {showBanner && (
+            <AlertBanner color="blue">
+              <div>
+                Looks like you're not a member yet!{' '}
+                <a
+                  href="/membership"
+                  className="underline underline-offset-2 font-semibold hover:opacity-80 transition"
+                >
+                  Purchase a membership
+                </a>{' '}
+                to gain access to all features! 🚀
+              </div>
+            </AlertBanner>
+          )}
 
           {children}
         </main>

--- a/components/AlertBanner.tsx
+++ b/components/AlertBanner.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { AlertCircleIcon } from "lucide-react";
+
+type AlertBannerProps = {
+  children: React.ReactNode;
+  color?: "red" | "green" | "yellow" | "blue";
+};
+
+const colorClasses = {
+  red: "bg-red-100 text-red-800 border-red-300",
+  green: "bg-green-100 text-green-800 border-green-300",
+  yellow: "bg-yellow-100 text-yellow-800 border-yellow-300",
+  blue: "bg-blue-100 text-blue-800 border-blue-300",
+};
+
+export function AlertBanner({ children, color = "blue" }: AlertBannerProps) {
+  return (
+    <div
+      className={cn(
+        "w-full flex flex-row items-center gap-2 px-4 py-3 border text-sm font-medium shadow-sm rounded-md",
+        colorClasses[color]
+      )}
+      role="alert"
+    >
+      <AlertCircleIcon/>
+      {children}
+    </div>
+  );
+}

--- a/components/forms/SignUpForm.tsx
+++ b/components/forms/SignUpForm.tsx
@@ -121,8 +121,7 @@ export default function SignUpForm() {
                 <>
                   <CreditCardIcon />
                   <div>
-                    {' '}
-                    Continue to payment with <b>Stripe</b>{' '}
+                    {' '} Create Account {' '}
                   </div>
                 </>
               )}

--- a/lib/types/user.ts
+++ b/lib/types/user.ts
@@ -1,4 +1,4 @@
-export type Role = "GUEST" | "MEMBER" | "EXECUTIVE" | "ADMIN";
+export type Role = "GUEST" | "BASIC" | "MEMBER" | "ADMIN";
 
 export interface UserProfileData {
     name: string,


### PR DESCRIPTION
## 📌 Summary

Adding user role "Basic" as the default role for new users and rendering a banner urging them to purchase membership


## ✅ What’s Changed?

- Default user role in DB
- Banner conditional render


## 🔍 How to Test

Steps to test this PR locally (if needed):

1. `pnpm run dev`
2. Login with user:"test@gmail.com" pw:"testpass"
3. Verify that banner is rendering.